### PR TITLE
Disable DebugHudMixin when OptiFabric is detected

### DIFF
--- a/src/main/java/io/github/joaoh1/boringtweaks/BoringTweaksPlugin.java
+++ b/src/main/java/io/github/joaoh1/boringtweaks/BoringTweaksPlugin.java
@@ -1,0 +1,38 @@
+package io.github.joaoh1.boringtweaks;
+
+import net.fabricmc.loader.api.FabricLoader;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class BoringTweaksPlugin implements IMixinConfigPlugin {
+	@Override
+	public void onLoad(String mixinPackage) {}
+
+	@Override
+	public String getRefMapperConfig() {
+		return null;
+	}
+
+	@Override
+	public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+		return !(FabricLoader.getInstance().isModLoaded("optifabric") && mixinClassName.endsWith("DebugHudMixin"));
+	}
+
+	@Override
+	public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {}
+
+	@Override
+	public List<String> getMixins() {
+		return null;
+	}
+
+	@Override
+	public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+
+	@Override
+	public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {}
+}

--- a/src/main/java/io/github/joaoh1/boringtweaks/config/BoringTweaksConfig.java
+++ b/src/main/java/io/github/joaoh1/boringtweaks/config/BoringTweaksConfig.java
@@ -24,7 +24,7 @@ public class BoringTweaksConfig {
 		.applyFromPojo(POJO, ANNOTATED_SETTINGS)
 		.build();
 	
-	private static JanksonValueSerializer serializer = new JanksonValueSerializer(false);
+	private static final JanksonValueSerializer serializer = new JanksonValueSerializer(false);
 
 	public static void loadModConfig() {
 		if (Files.exists(CONFIG_PATH)) {

--- a/src/main/java/io/github/joaoh1/boringtweaks/config/BoringTweaksConfigPojo.java
+++ b/src/main/java/io/github/joaoh1/boringtweaks/config/BoringTweaksConfigPojo.java
@@ -26,7 +26,7 @@ public class BoringTweaksConfigPojo {
 		@Setting(comment = "Fixes baby biped's hat layer")
 		public boolean fixBabyHatLayer = true;
 
-		@Setting(comment = "Adds shadows on the debug HUD's text")
+		@Setting(comment = "Adds shadows on the debug HUD's text (incompatible with OpfiFine)")
 		public boolean shadowedDebugHud = false;
 
 		@Setting(comment = "Enables the Strider easter egg")

--- a/src/main/resources/assets/boringtweaks/lang/en_us.json
+++ b/src/main/resources/assets/boringtweaks/lang/en_us.json
@@ -14,7 +14,7 @@
     "config.boringtweaks.fix_baby_hat_layer": "Fix Baby Hat Layer",
     "config.boringtweaks.fix_baby_hat_layer.tooltip": "Fixes the hat layer of baby bipeds",
     "config.boringtweaks.shadowed_debug_hud": "Shadowed Debug HUD",
-    "config.boringtweaks.shadowed_debug_hud.tooltip": "Adds shadows on the debug HUD's text",
+    "config.boringtweaks.shadowed_debug_hud.tooltip": "Adds shadows on the debug HUD's text (Incompatible with OptiFine)",
     "config.boringtweaks.strider_easter_egg": "Strider Easter Egg",
     "config.boringtweaks.strider_easter_egg.tooltip": "Enables the Strider easter egg",
     "config.boringtweaks.category.values": "Values",

--- a/src/main/resources/assets/boringtweaks/lang/pt_br.json
+++ b/src/main/resources/assets/boringtweaks/lang/pt_br.json
@@ -14,7 +14,7 @@
     "config.boringtweaks.fix_baby_hat_layer": "Arrumar a camada de chapéu de bebês",
     "config.boringtweaks.fix_baby_hat_layer.tooltip": "Arruma a camada de chapéu de bebês bípedes",
     "config.boringtweaks.shadowed_debug_hud": "HUD de debug sombreado",
-    "config.boringtweaks.shadowed_debug_hud.tooltip": "Adiciona sombras no texto do HUD de debug",
+    "config.boringtweaks.shadowed_debug_hud.tooltip": "Adiciona sombras no texto do HUD de debug (Incompatível com OptiFine)",
     "config.boringtweaks.strider_easter_egg": "Easter egg dos andarilhos",
     "config.boringtweaks.strider_easter_egg.tooltip": "Adiciona um easter egg para os andarilhos",
     "config.boringtweaks.category.values": "Valores",

--- a/src/main/resources/assets/boringtweaks/lang/tr_tr.json
+++ b/src/main/resources/assets/boringtweaks/lang/tr_tr.json
@@ -14,7 +14,7 @@
     "config.boringtweaks.fix_baby_hat_layer": "Bebek Şapka Katmanını Düzelt",
     "config.boringtweaks.fix_baby_hat_layer.tooltip": "İki ayaklı bebeklerin şapka katmanını düzeltir",
     "config.boringtweaks.shadowed_debug_hud": "Gölgeli Hata Ayıklama HUD'u",
-    "config.boringtweaks.shadowed_debug_hud.tooltip": "Hata Ayıklama HUD'undaki metne gölge ekler",
+    "config.boringtweaks.shadowed_debug_hud.tooltip": "Hata Ayıklama HUD'undaki metne gölge ekler (OptiFine ile uyumsuz)",
     "config.boringtweaks.strider_easter_egg": "Lavgezer Easter Egg'i",
     "config.boringtweaks.strider_easter_egg.tooltip": "Lavgezer Easter Egg'ini etkinleştirir.",
     "config.boringtweaks.category.values": "Değerler",

--- a/src/main/resources/boringtweaks.mixins.json
+++ b/src/main/resources/boringtweaks.mixins.json
@@ -2,6 +2,7 @@
   "required": true,
   "package": "io.github.joaoh1.boringtweaks.mixin",
   "compatibilityLevel": "JAVA_8",
+  "plugin": "io.github.joaoh1.boringtweaks.BoringTweaksPlugin",
   "client": [
     "BipedEntityModelMixin",
     "DebugHudMixin",


### PR DESCRIPTION
## Issue

The combination BoringTweaks + OptiFabric + OptiFine crashes on startup:
> org.spongepowered.asm.mixin.transformer.throwables.MixinTransformerError: An unexpected critical error was encountered
	at org.spongepowered.asm.mixin.transformer.MixinProcessor.applyMixins(MixinProcessor.java:363)
> (...)
> Caused by: org.spongepowered.asm.mixin.injection.throwables.InjectionError: Critical injection failure: Redirector renderHudWithShadow(Lnet/minecraft/class_327;Lnet/minecraft/class_4587;Ljava/lang/String;FFI)I in boringtweaks.mixins.json:DebugHudMixin failed injection check, (0/1) succeeded. Scanned 2 target(s). Using refmap boringtweaks-refmap.json

## Fix

Conditionally disabling `DebugHudMixin` fixes the issue.
Setting `"injectors": { "defaultRequire": 0 }` fixes the crash too, but then you won't know if a mixin fails.

I couldn't find a way to gray out or otherwise disable options inside ModMenu, so I adjusted the description.